### PR TITLE
Fixing leaf encoding truncation issue

### DIFF
--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -103,6 +103,7 @@ class MisicProximityStd(ABC):
         """
         X_leaves = np.empty(gbm_model.n_trees,dtype='str')
         for tree in range(gbm_model.n_trees):
+            print("Tree:",str(tree))
             # Identify which nodes are leaves.
             leaves = list(gbm_model.get_leaf_encodings(tree))
             encoding = '' # Start at the root, walk until we reach a leaf.

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -101,7 +101,7 @@ class MisicProximityStd(ABC):
             each branch point of the tree.
             
         """
-        X_leaves = np.empty(gbm_model.n_trees,dtype='str')
+        X_leaves = np.empty(gbm_model.n_trees,dtype='U')
         for tree in range(gbm_model.n_trees):
             print("Tree:",str(tree))
             # Identify which nodes are leaves.

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -129,7 +129,8 @@ class MisicProximityStd(ABC):
                     # Determine which of these is the smallest
                     best_leaf = possible_leaves[np.argmin(possible_weights)]
                     # Move one step down that branch of the tree
-                    encoding = encoding + best_leaf[len(encoding)]                
+                    encoding = encoding + best_leaf[len(encoding)] 
+                print(encoding)
             # Add this leaf to the set and move onto the next tree.
             X_leaves[tree] = encoding
         return X_leaves

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -211,9 +211,7 @@ class MisicProximityStd(ABC):
                 for j in range(n_trees):
                     # Construct the leaf variable name
                     leafvar_name = "z_l[" + label + "," + str(j) + "," + str(self.ref_leaves[observation][j])+"]"
-                    print(leafvar_name)
                     leafvar = model.getVarByName(leafvar_name)
-                    print(leafvar)
                     prox_obs.addTerms([1],[leafvar])
                 
                 # Add constraint to model.

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -26,7 +26,6 @@ class MisicProximityStd(ABC):
     """
     def __init__(self,threshold=0.9):
         self.threshold = threshold
-        print("Boop")
         # define the distance metric for continuous variables
 
     def set_params(self,**kwargs):
@@ -101,9 +100,8 @@ class MisicProximityStd(ABC):
             each branch point of the tree.
             
         """
-        X_leaves = np.empty(gbm_model.n_trees,dtype='U32')
+        X_leaves = np.empty(gbm_model.n_trees,dtype='U32') # Assuming no regressors go deeper than 32 branches
         for tree in range(gbm_model.n_trees):
-            print("Tree:",str(tree))
             # Identify which nodes are leaves.
             leaves = list(gbm_model.get_leaf_encodings(tree))
             encoding = '' # Start at the root, walk until we reach a leaf.
@@ -131,10 +129,8 @@ class MisicProximityStd(ABC):
                     best_leaf = possible_leaves[np.argmin(possible_weights)]
                     # Move one step down that branch of the tree
                     encoding = encoding + best_leaf[len(encoding)] 
-            print(encoding)
             # Add this leaf to the set and move onto the next tree.
             X_leaves[tree] = encoding
-            print(X_leaves)
         return X_leaves
 
     def get_closest_point_proximity(self, X):

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -26,7 +26,7 @@ class MisicProximityStd(ABC):
     """
     def __init__(self,threshold=0.9):
         self.threshold = threshold
-        
+        print("Boop")
         # define the distance metric for continuous variables
 
     def set_params(self,**kwargs):
@@ -212,7 +212,9 @@ class MisicProximityStd(ABC):
                 for j in range(n_trees):
                     # Construct the leaf variable name
                     leafvar_name = "z_l[" + label + "," + str(j) + "," + str(self.ref_leaves[observation][j])+"]"
+                    print(leafvar_name)
                     leafvar = model.getVarByName(leafvar_name)
+                    print(leafvar)
                     prox_obs.addTerms([1],[leafvar])
                 
                 # Add constraint to model.

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -130,7 +130,7 @@ class MisicProximityStd(ABC):
                     best_leaf = possible_leaves[np.argmin(possible_weights)]
                     # Move one step down that branch of the tree
                     encoding = encoding + best_leaf[len(encoding)] 
-                print(encoding)
+            print(encoding)
             # Add this leaf to the set and move onto the next tree.
             X_leaves[tree] = encoding
         return X_leaves

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -134,6 +134,7 @@ class MisicProximityStd(ABC):
             print(encoding)
             # Add this leaf to the set and move onto the next tree.
             X_leaves[tree] = encoding
+            print(X_leaves)
         return X_leaves
 
     def get_closest_point_proximity(self, X):

--- a/entmoot/learning/proximity_std.py
+++ b/entmoot/learning/proximity_std.py
@@ -101,7 +101,7 @@ class MisicProximityStd(ABC):
             each branch point of the tree.
             
         """
-        X_leaves = np.empty(gbm_model.n_trees,dtype='U')
+        X_leaves = np.empty(gbm_model.n_trees,dtype='U32')
         for tree in range(gbm_model.n_trees):
             print("Tree:",str(tree))
             # Identify which nodes are leaves.


### PR DESCRIPTION
I set the dtype of the encoding to U32, which should be long enough for most trees.